### PR TITLE
Improve SPI Slave CS to CLK delay

### DIFF
--- a/modules/hil/lib_spi/api/spi.h
+++ b/modules/hil/lib_spi/api/spi.h
@@ -317,8 +317,9 @@ typedef struct {
 /**
  * Initializes a SPI slave.
  *
- * Note: Verified at 25000 kbps, with a 3000ns CS assertion to first clock
-  *      in all modes.
+ * Note: Verified at 25000 kbps, with a 2000ns CS assertion to first clock
+ *       in all modes.  The CS to first clock minimum delay will vary based
+ *       on the duration of the slave_transaction_started callback.
  *
  * \param spi_cbg     The spi_slave_callback_group_t context to use.
  * \param p_sclk      The SPI slave's SCLK port. Must be a 1-bit port.

--- a/modules/hil/lib_spi/src/spi_slave.c
+++ b/modules/hil/lib_spi/src/spi_slave.c
@@ -140,13 +140,29 @@ __attribute__((always_inline))
 static inline uint32_t get_next_word(internal_ctx_t *ctx) {
     uint32_t out_word = 0;
 
-    for (int i=0; i<4; i++)
+    if (ctx->out_buf_cur < ctx->out_buf_end)
     {
-        if (ctx->out_buf_cur >= ctx->out_buf_end) {
-            break;
-        } else {
-            out_word |= bitrev(*(ctx->out_buf_cur) << (24 - (8*i)));
-            ctx->out_buf_cur++;
+        out_word = *(uint32_t*)ctx->out_buf_cur;
+        out_word = bitrev(out_word);
+        out_word = byterev(out_word);
+        switch(ctx->out_buf_end - ctx->out_buf_cur)
+        {
+            default:
+            case 4:
+                ctx->out_buf_cur += 4;
+                break;
+            case 3:
+                out_word &= 0xFFFFFF00;
+                ctx->out_buf_cur += 3;
+                break;
+            case 2:
+                out_word &= 0xFFFF0000;
+                ctx->out_buf_cur += 2;
+                break;
+            case 1:
+                out_word &= 0xFF000000;
+                ctx->out_buf_cur += 1;
+                break;
         }
     }
 

--- a/test/hil/lib_spi/spi_slave_rx_tx/src/main.c
+++ b/test/hil/lib_spi/spi_slave_rx_tx/src/main.c
@@ -28,7 +28,7 @@ port_t setup_resp_port = XS1_PORT_1F;
 #define KBPS 25000
 
 #ifndef INITIAL_CLOCK_DELAY
-#define INITIAL_CLOCK_DELAY 3000
+#define INITIAL_CLOCK_DELAY 2000
 #endif
 
 static const uint8_t tx_data[NUMBER_OF_TEST_BYTES] = {

--- a/test/hil/lib_spi/test_slave_rx_tx.py
+++ b/test/hil/lib_spi/test_slave_rx_tx.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import Pyxsim as px
 import pytest
 
+DEBUG_MODE = 0
+
 mode_args = {"mode_0": 0,
              "mode_1": 1,
              "mode_2": 2,
@@ -53,17 +55,23 @@ def test_spi_slave_rx_tx(build, capfd, request, full_load, miso_enabled, mosi_en
                                             regexp = True,
                                             ordered = True,
                                             suppress_multidrive_messages = False)
-                                            
-    build(directory = binary, 
-            env = {"FULL_LOAD":f'{full_load}', 
+
+    build(directory = binary,
+            env = {"FULL_LOAD":f'{full_load}',
                    "MISO_ENABLED":f'{miso_enabled}',
                    "MOSI_ENABLED":f'{mosi_enabled}',
                    "SPI_MODE":f'{mode}',
                    "IN_PLACE":f'{in_place}'},
             bin_child = id_string)
 
-    px.run_with_pyxsim(binary,
-                       simthreads = [checker]
-                       )
+    if DEBUG_MODE:
+        with capfd.disabled():
+            px.run_with_pyxsim(binary,
+                               simthreads = [checker]
+                               )
+    else:
+        px.run_with_pyxsim(binary,
+                           simthreads = [checker]
+                           )
 
-    tester.run(capfd.readouterr().out)
+        tester.run(capfd.readouterr().out)


### PR DESCRIPTION
It was experimentally found with xsim that an improvement of
get_next_word could allow the spi_slave_rx_tx test to pass with the same
CS to CLK delay as the legacy XC implementation.  This commit improves
each call to get_next_word from 50 to 14 ticks.

Closes #237 