### PR TITLE
Add new callback to DCD USB handler

### DIFF
--- a/modules/rtos/sw_services/usb/portable/dcd_xcore.c
+++ b/modules/rtos/sw_services/usb/portable/dcd_xcore.c
@@ -2,6 +2,7 @@
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #define DEBUG_UNIT TUSB_DCD
+#define DEBUG_PRINT_ENABLE_TUSB_DCD 0
 
 #include "device/dcd.h"
 #include "device/usbd.h" /* For tud_descriptor_configuration_cb() */
@@ -30,6 +31,7 @@
 #endif
 
 TU_ATTR_WEAK bool tud_xcore_sof_cb(uint8_t rhport);
+TU_ATTR_WEAK void tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len);
 
 #include "rtos_usb.h"
 
@@ -102,6 +104,18 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
         return;
     }
 
+    /* Timestamp packets as they come in */
+
+    uint32_t cur_time;
+    asm volatile(
+           "{gettime %0}"
+           : "=r"(cur_time)
+           : /* no resources*/
+           : /* no clobbers */
+           );
+
+    // rtos_printf("packet rx'd, timestamp %d\n", cur_time); 
+
     switch (packet_type) {
     case rtos_usb_data_packet: {
         xfer_result_t tu_result;
@@ -138,6 +152,12 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
             rtos_printf("xfer on %02x failed with status %d\n", ep_address, res);
             tu_result = XFER_RESULT_FAILED;
             xfer_len = 0;
+        }
+
+        if (tud_xcore_data_cb) {
+            uint32_t ep_num = tu_edpt_number(ep_address);
+            uint32_t ep_dir = tu_edpt_dir(ep_address);
+            tud_xcore_data_cb(cur_time, ep_num, ep_dir, xfer_len);
         }
 
         dcd_event_xfer_complete(0, ep_address, xfer_len, tu_result, true);

--- a/modules/rtos/sw_services/usb/portable/dcd_xcore.c
+++ b/modules/rtos/sw_services/usb/portable/dcd_xcore.c
@@ -31,7 +31,7 @@
 #endif
 
 TU_ATTR_WEAK bool tud_xcore_sof_cb(uint8_t rhport);
-TU_ATTR_WEAK void tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len);
+TU_ATTR_WEAK bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len);
 
 #include "rtos_usb.h"
 
@@ -119,6 +119,7 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
     switch (packet_type) {
     case rtos_usb_data_packet: {
         xfer_result_t tu_result;
+        bool cb_result;
 
         if (res == XUD_RES_OKAY) {
             rtos_printf("xfer of %d bytes complete on %02x\n", xfer_len, ep_address);
@@ -157,7 +158,7 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
         if (tud_xcore_data_cb) {
             uint32_t ep_num = tu_edpt_number(ep_address);
             uint32_t ep_dir = tu_edpt_dir(ep_address);
-            tud_xcore_data_cb(cur_time, ep_num, ep_dir, xfer_len);
+            cb_result = tud_xcore_data_cb(cur_time, ep_num, ep_dir, xfer_len);
         }
 
         dcd_event_xfer_complete(0, ep_address, xfer_len, tu_result, true);

--- a/modules/rtos/sw_services/usb/portable/dcd_xcore.c
+++ b/modules/rtos/sw_services/usb/portable/dcd_xcore.c
@@ -98,12 +98,6 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
                                   rtos_usb_packet_type_t packet_type,
                                   XUD_Result_t res)
 {
-    if (res == XUD_RES_RST) {
-        rtos_printf("Reset received on %02x\n", ep_address);
-        reset_ep(ep_address, true);
-        return;
-    }
-
     /* Timestamp packets as they come in */
 
     uint32_t cur_time;
@@ -113,6 +107,12 @@ static void dcd_xcore_int_handler(rtos_usb_t *ctx,
            : /* no resources*/
            : /* no clobbers */
            );
+
+    if (res == XUD_RES_RST) {
+        rtos_printf("Reset received on %02x\n", ep_address);
+        reset_ep(ep_address, true);
+        return;
+    }
 
     // rtos_printf("packet rx'd, timestamp %d\n", cur_time); 
 


### PR DESCRIPTION
As part of #303 - thought I'd spin it off into a separate PR!

This PR does two things:

 - Adds a new instruction to `dcd_xcore_int_handler` capturing the packet timestamp at time of call in terms of the reference clock and storing in a new variable `uint32_t cur_time`.
 - Adds a new callback to `dcd_xcore_int_handler` in the USB data packet handling logic with the following signature:

```c
bool tud_xcore_data_cb(uint32_t cur_time, uint32_t ep_num, uint32_t ep_dir, size_t xfer_len);
```
where

  - `cur_time` is the timestamp of the packet transmitted, in terms of the reference clock.
  - `ep_num` is the number of the endpoint over which the packet has been transmitted.
  - `ep_dir` is the direction of the endpoint over which the packet has been transmitted.
  - `xfer_len` is the length of the data packet transmitted.

The function currently expects a `bool` return, but does nothing with this return value. This opens the possibility of application callbacks being able to modify behaviour of the DCD dynamically. It is suggested for forwards-compatibility that applications that implement this callback set the return to `True` in line with the expectations of `tud_xcore_sof_cb`, where a return value of `True` instructs TinyUSB to send the SOF event to the stack.