### PR TITLE
Feature/cmake ninja support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@
 build/
 
 # filesystem cruft
+**/fatmktmp
 **/fat.fs
 **/flash_bin_node0
 **/fw-*

--- a/examples/bare-metal/explorer_board/explorer_board.cmake
+++ b/examples/bare-metal/explorer_board/explorer_board.cmake
@@ -49,7 +49,7 @@ set(APP_LINK_OPTIONS
 #**********************
 # Tile Targets
 #**********************
-add_executable(example_bare_metal_explorer_board EXCLUDE_FROM_ALL)
+add_executable(example_bare_metal_explorer_board)
 target_sources(example_bare_metal_explorer_board PUBLIC ${APP_SOURCES})
 target_include_directories(example_bare_metal_explorer_board PUBLIC ${APP_INCLUDES})
 target_compile_definitions(example_bare_metal_explorer_board PRIVATE ${APP_COMPILE_DEFINITIONS})

--- a/examples/freertos/l2_cache/l2_cache.cmake
+++ b/examples/freertos/l2_cache/l2_cache.cmake
@@ -65,8 +65,8 @@ create_install_target(example_freertos_l2_cache)
 add_custom_command(
     TARGET example_freertos_l2_cache POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory example_freertos_l2_cache_split
-    COMMAND xobjdump --strip example_freertos_l2_cache.xe
-    COMMAND xobjdump --split --split-dir example_freertos_l2_cache_split example_freertos_l2_cache.xb
+    COMMAND xobjdump --strip example_freertos_l2_cache.xe > example_freertos_l2_cache_split/output.log
+    COMMAND xobjdump --split --split-dir example_freertos_l2_cache_split example_freertos_l2_cache.xb >> example_freertos_l2_cache_split/output.log
     BYPRODUCTS
         example_freertos_l2_cache.xb
         example_freertos_l2_cache_split

--- a/examples/freertos/l2_cache/l2_cache.cmake
+++ b/examples/freertos/l2_cache/l2_cache.cmake
@@ -69,8 +69,11 @@ add_custom_command(
     COMMAND xobjdump --split --split-dir example_freertos_l2_cache_split example_freertos_l2_cache.xb >> example_freertos_l2_cache_split/output.log
     BYPRODUCTS
         example_freertos_l2_cache.xb
-        example_freertos_l2_cache_split
     VERBATIM
+)
+
+set_target_properties(example_freertos_l2_cache PROPERTIES
+    ADDITIONAL_CLEAN_FILES example_freertos_l2_cache_split
 )
 
 #**********************

--- a/examples/freertos/tracealyzer/host/xscope2psf.c
+++ b/examples/freertos/tracealyzer/host/xscope2psf.c
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 #include "xscope_endpoint.h"
 
-#define VERSION "1.0.1"
+#define VERSION "1.0.2"
 
 // Abstraction for sleep portability
 #if defined(__GNUC__) || defined(__MINGW32__)
@@ -174,7 +174,7 @@ static void print_help(char *arg0)
            "                                for --stream. Default = 1000.\n");
     printf("    -i, --in-file <IN_FILE>     The VCD file to process. In stream mode, the\n"
            "                                application will wait for such a file to exist.\n");
-    printf("    -I, --in-port <HOST>:<PORT> The host and port (separated by ':') on the which\n"
+    printf("    -I, --in-port <HOST>:<PORT> The host and port (separated by ':') on which\n"
            "                                xgdb's --xscope-port is serving on.\n"
            "                                Note: --stream is implied when using this mode.\n");
     printf("    -o, --out-file <OUT_FILE>   The PSF file to generate.\n");


### PR DESCRIPTION
Similar set of changes as RTOS module's changes for Ninja support.

One thing I noticed during this update was that the `create_filesystem_target` does not appear to be too useful. Contrary to the macro's name, it only copies a file to another location (as the comment in the macro suggests). I was considering options to make this be what calls `fatfs_mkimage`, or possibly getting rid of this target and adapt the existing logic that calls `fatfs_mkimage` to output to the desired directory. But for now, I decided to leave it as is, and see if anyone has an opinion on this.