### PR TITLE
fix url to hardware guide

### DIFF
--- a/doc/tutorials/platform.rst
+++ b/doc/tutorials/platform.rst
@@ -6,7 +6,7 @@ Platform
 Architecture & Hardware Guide
 *****************************
 
-See the `Architecture & Hardware Guide <https://www.xmos.ai/documentation/XM-014363-PC-LATEST/html/arch-hw-guide/index.html>`_ in the XTC Tools documentation for an introduction to the xcore platform architecture and hardware.
+See the `Architecture & Hardware Guide <https://www.xmos.ai/documentation/XM-014363-PC-LATEST/html/prog-guide/arch-hw-guide/index.html>`_ in the XTC Tools documentation for an introduction to the xcore platform architecture and hardware.
 
 *****************
 Programming Guide


### PR DESCRIPTION
It looks like that url has changed as well since the [last failing build](https://github.com/xmos/xcore_sdk/actions/runs/4167084968/jobs/7212233734) I was comparing to.

-----------------
Also it seems the previous fix #582 needs to be applied to the rtos submodule as well.
I don't know what your submodule update process is here, should I leave this PR open and make another there then update the submodule in this PR?

------------------
Just seen you've fixed the URL on develop already. Shall I just update the submodule then?